### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -106,7 +106,7 @@ jobs:
         compression-level: 9
 
     - name: Login to Docker Hub
-      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@fc3d69cb98fb60b80a6009169959831d4f49ee7d  # v1.20250309.1
+        uses: ThreatFlux/githubWorkFlowChecker@bd0587c86dc761b69ab0d3eb000a01974b2eb619  # v1.20250314.1
         with:
           owner: ${{ github.repository_owner }}
           repo-name: ${{ github.event.repository.name }}


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `docker/login-action`
  * From: 9780b0c442fbb1117ed29e0efdff1e18412f7567 (9780b0c442fbb1117ed29e0efdff1e18412f7567)
  * To: v3.4.0 (74a5d142397b4f367a81961eba4e8cd7edddf772)

* `ThreatFlux/githubWorkFlowChecker`
  * From: fc3d69cb98fb60b80a6009169959831d4f49ee7d (fc3d69cb98fb60b80a6009169959831d4f49ee7d)
  * To: v1.20250314.1 (bd0587c86dc761b69ab0d3eb000a01974b2eb619)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.