### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -57,7 +57,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       with:
         name: test-results-py${{ matrix.python-version }}-${{ matrix.docker-stage }}
         path: |
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Set up Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
         with:
           python-version: '3.13'
       

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
       with:
         python-version: '3.13'
         cache: 'pip'
@@ -94,7 +94,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       with:
         name: release-artifacts-v${{ steps.get_version.outputs.version }}
         path: |

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@bd0587c86dc761b69ab0d3eb000a01974b2eb619  # v1.20250314.1
+        uses: ThreatFlux/githubWorkFlowChecker@b85ebeb97aebf83af4773d96738922a065a77037  # v1.20250408.1
         with:
           owner: ${{ github.repository_owner }}
           repo-name: ${{ github.event.repository.name }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -22,7 +22,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
       with:
         python-version: '3.13'
 


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/setup-python`
  * From: 42375524e23c412d93fb67b49958b491fce71c38 (42375524e23c412d93fb67b49958b491fce71c38)
  * To: v5.5.0 (8d9ed9ac5c53483de85588cdf95a591a75ab9f55)

* `actions/upload-artifact`
  * From: 4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 (4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1)
  * To: v4.6.2 (ea165f8d65b6e75b540449e92b4886f43607fa02)

* `actions/setup-python`
  * From: 42375524e23c412d93fb67b49958b491fce71c38 (42375524e23c412d93fb67b49958b491fce71c38)
  * To: v5.5.0 (8d9ed9ac5c53483de85588cdf95a591a75ab9f55)

* `actions/setup-python`
  * From: 42375524e23c412d93fb67b49958b491fce71c38 (42375524e23c412d93fb67b49958b491fce71c38)
  * To: v5.5.0 (8d9ed9ac5c53483de85588cdf95a591a75ab9f55)

* `actions/upload-artifact`
  * From: 4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 (4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1)
  * To: v4.6.2 (ea165f8d65b6e75b540449e92b4886f43607fa02)

* `ThreatFlux/githubWorkFlowChecker`
  * From: bd0587c86dc761b69ab0d3eb000a01974b2eb619 (bd0587c86dc761b69ab0d3eb000a01974b2eb619)
  * To: v1.20250408.1 (b85ebeb97aebf83af4773d96738922a065a77037)

* `actions/setup-python`
  * From: 42375524e23c412d93fb67b49958b491fce71c38 (42375524e23c412d93fb67b49958b491fce71c38)
  * To: v5.5.0 (8d9ed9ac5c53483de85588cdf95a591a75ab9f55)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.