### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         # Test production stage health check
         make docker-test
     - name: Upload coverage reports
-      uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574  # v5.4.0
+      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -79,7 +79,7 @@ jobs:
         echo "- \`threatflux/yaraflux-mcp-server:${{ steps.get_version.outputs.version }}\` (production)" >> RELEASE_NOTES.md
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
+      uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631  # v2.2.2
       with:
         tag_name: v${{ steps.get_version.outputs.version }}
         name: Release v${{ steps.get_version.outputs.version }}

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@b85ebeb97aebf83af4773d96738922a065a77037  # v1.20250408.1
+        uses: ThreatFlux/githubWorkFlowChecker@77ce48e4752c1c1dc52fb67138d9d5558d604370  # v1.20250420.1
         with:
           owner: ${{ github.repository_owner }}
           repo-name: ${{ github.event.repository.name }}


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `codecov/codecov-action`
  * From: 0565863a31f2c772f9f0395002a31e3f06189574 (0565863a31f2c772f9f0395002a31e3f06189574)
  * To: v5.4.2 (ad3126e916f78f00edff4ed0317cf185271ccc2d)

* `softprops/action-gh-release`
  * From: c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda (c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda)
  * To: v2.2.2 (da05d552573ad5aba039eaac05058a918a7bf631)

* `ThreatFlux/githubWorkFlowChecker`
  * From: b85ebeb97aebf83af4773d96738922a065a77037 (b85ebeb97aebf83af4773d96738922a065a77037)
  * To: v1.20250420.1 (77ce48e4752c1c1dc52fb67138d9d5558d604370)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.