### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Set up Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
       

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: '3.13'
         cache: 'pip'

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@77ce48e4752c1c1dc52fb67138d9d5558d604370  # v1.20250420.1
+        uses: ThreatFlux/githubWorkFlowChecker@31190975e98d04d482a09ae5cabcc5786010aac6  # v1.20250511.1
         with:
           owner: ${{ github.repository_owner }}
           repo-name: ${{ github.event.repository.name }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -22,7 +22,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Python
-      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: '3.13'
 


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/setup-python`
  * From: 8d9ed9ac5c53483de85588cdf95a591a75ab9f55 (8d9ed9ac5c53483de85588cdf95a591a75ab9f55)
  * To: v5.6.0 (a26af69be951a213d495a4c3e4e4022e16d87065)

* `actions/setup-python`
  * From: 8d9ed9ac5c53483de85588cdf95a591a75ab9f55 (8d9ed9ac5c53483de85588cdf95a591a75ab9f55)
  * To: v5.6.0 (a26af69be951a213d495a4c3e4e4022e16d87065)

* `actions/setup-python`
  * From: 8d9ed9ac5c53483de85588cdf95a591a75ab9f55 (8d9ed9ac5c53483de85588cdf95a591a75ab9f55)
  * To: v5.6.0 (a26af69be951a213d495a4c3e4e4022e16d87065)

* `ThreatFlux/githubWorkFlowChecker`
  * From: 77ce48e4752c1c1dc52fb67138d9d5558d604370 (77ce48e4752c1c1dc52fb67138d9d5558d604370)
  * To: v1.20250511.1 (31190975e98d04d482a09ae5cabcc5786010aac6)

* `actions/setup-python`
  * From: 8d9ed9ac5c53483de85588cdf95a591a75ab9f55 (8d9ed9ac5c53483de85588cdf95a591a75ab9f55)
  * To: v5.6.0 (a26af69be951a213d495a4c3e4e4022e16d87065)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.