### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@917e8a82917a418dba9b9726effe6f0cb3110b5a  # v1.20250601.3
+        uses: ThreatFlux/githubWorkFlowChecker@8ae902f9378405542b87df100c1236c6e737dac7  # v1.20250803.1
         with:
           owner: ${{ github.repository_owner }}
           repo-name: ${{ github.event.repository.name }}


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `ThreatFlux/githubWorkFlowChecker`
  * From: 917e8a82917a418dba9b9726effe6f0cb3110b5a (917e8a82917a418dba9b9726effe6f0cb3110b5a)
  * To: v1.20250803.1 (8ae902f9378405542b87df100c1236c6e737dac7)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.