### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -106,7 +106,7 @@ jobs:
         compression-level: 9
 
     - name: Login to Docker Hub
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@917e8a82917a418dba9b9726effe6f0cb3110b5a  # v1.20250601.3
+        uses: ThreatFlux/githubWorkFlowChecker@8ae902f9378405542b87df100c1236c6e737dac7  # v1.20250803.1
         with:
           owner: ${{ github.repository_owner }}
           repo-name: ${{ github.event.repository.name }}


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `docker/login-action`
  * From: 74a5d142397b4f367a81961eba4e8cd7edddf772 (74a5d142397b4f367a81961eba4e8cd7edddf772)
  * To: v3.5.0 (184bdaa0721073962dff0199f1fb9940f07167d1)

* `ThreatFlux/githubWorkFlowChecker`
  * From: 917e8a82917a418dba9b9726effe6f0cb3110b5a (917e8a82917a418dba9b9726effe6f0cb3110b5a)
  * To: v1.20250803.1 (8ae902f9378405542b87df100c1236c6e737dac7)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.