### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         docker-stage: [builder, development, production]
 
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
@@ -71,7 +71,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ jobs:
       packages: write
     
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       with:
         fetch-depth: 0
 
@@ -106,7 +106,7 @@ jobs:
         compression-level: 9
 
     - name: Login to Docker Hub
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/safety_scan.yml
+++ b/.github/workflows/safety_scan.yml
@@ -4,7 +4,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Run Safety CLI to check for vulnerabilities
         uses: pyupio/safety-action@2591cf2f3e67ba68b923f4c92f0d36e281c65023  # v1.0.1
         with:

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -14,9 +14,9 @@ jobs:
       actions: read           # Required to read workflow files
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@917e8a82917a418dba9b9726effe6f0cb3110b5a  # v1.20250601.3
+        uses: ThreatFlux/githubWorkFlowChecker@26a6118d69047c9ddf3386e9216b423ee9b2e9ee  # v1.20250813.1
         with:
           owner: ${{ github.repository_owner }}
           repo-name: ${{ github.event.repository.name }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `docker/login-action`
  * From: 74a5d142397b4f367a81961eba4e8cd7edddf772 (74a5d142397b4f367a81961eba4e8cd7edddf772)
  * To: v3.5.0 (184bdaa0721073962dff0199f1fb9940f07167d1)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `ThreatFlux/githubWorkFlowChecker`
  * From: 917e8a82917a418dba9b9726effe6f0cb3110b5a (917e8a82917a418dba9b9726effe6f0cb3110b5a)
  * To: v1.20250813.1 (26a6118d69047c9ddf3386e9216b423ee9b2e9ee)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.