### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -51,7 +51,7 @@ jobs:
         # Test production stage health check
         make docker-test
     - name: Upload coverage reports
-      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24  # v5.4.3
+      uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7  # v5.5.1
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
         with:
           python-version: '3.13'
       

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
       with:
         python-version: '3.13'
         cache: 'pip'
@@ -79,7 +79,7 @@ jobs:
         echo "- \`threatflux/yaraflux-mcp-server:${{ steps.get_version.outputs.version }}\` (production)" >> RELEASE_NOTES.md
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8  # v2.3.2
+      uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836  # v2.3.3
       with:
         tag_name: v${{ steps.get_version.outputs.version }}
         name: Release v${{ steps.get_version.outputs.version }}
@@ -121,7 +121,7 @@ jobs:
 
     - name: Notify on failure
       if: failure()
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
       with:
         script: |
           github.rest.issues.create({

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@26a6118d69047c9ddf3386e9216b423ee9b2e9ee  # v1.20250813.1
+        uses: ThreatFlux/githubWorkFlowChecker@afa5343c5dbae66fbf7e9e35765e045c93bff630  # v1.20250907.1
         with:
           owner: ${{ github.repository_owner }}
           repo-name: ${{ github.event.repository.name }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -22,7 +22,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
       with:
         python-version: '3.13'
 


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/setup-python`
  * From: a26af69be951a213d495a4c3e4e4022e16d87065 (a26af69be951a213d495a4c3e4e4022e16d87065)
  * To: v6.0.0 (e797f83bcb11b83ae66e0230d6156d7c80228e7c)

* `codecov/codecov-action`
  * From: 18283e04ce6e62d37312384ff67231eb8fd56d24 (18283e04ce6e62d37312384ff67231eb8fd56d24)
  * To: v5.5.1 (5a1091511ad55cbe89839c7260b706298ca349f7)

* `actions/setup-python`
  * From: a26af69be951a213d495a4c3e4e4022e16d87065 (a26af69be951a213d495a4c3e4e4022e16d87065)
  * To: v6.0.0 (e797f83bcb11b83ae66e0230d6156d7c80228e7c)

* `actions/setup-python`
  * From: a26af69be951a213d495a4c3e4e4022e16d87065 (a26af69be951a213d495a4c3e4e4022e16d87065)
  * To: v6.0.0 (e797f83bcb11b83ae66e0230d6156d7c80228e7c)

* `softprops/action-gh-release`
  * From: 72f2c25fcb47643c292f7107632f7a47c1df5cd8 (72f2c25fcb47643c292f7107632f7a47c1df5cd8)
  * To: v2.3.3 (6cbd405e2c4e67a21c47fa9e383d020e4e28b836)

* `actions/github-script`
  * From: 60a0d83039c74a4aee543508d2ffcb1c3799cdea (60a0d83039c74a4aee543508d2ffcb1c3799cdea)
  * To: v8 (ed597411d8f924073f98dfc5c65a23a2325f34cd)

* `ThreatFlux/githubWorkFlowChecker`
  * From: 26a6118d69047c9ddf3386e9216b423ee9b2e9ee (26a6118d69047c9ddf3386e9216b423ee9b2e9ee)
  * To: v1.20250907.1 (afa5343c5dbae66fbf7e9e35765e045c93bff630)

* `actions/setup-python`
  * From: a26af69be951a213d495a4c3e4e4022e16d87065 (a26af69be951a213d495a4c3e4e4022e16d87065)
  * To: v6.0.0 (e797f83bcb11b83ae66e0230d6156d7c80228e7c)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.