### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -79,7 +79,7 @@ jobs:
         echo "- \`threatflux/yaraflux-mcp-server:${{ steps.get_version.outputs.version }}\` (production)" >> RELEASE_NOTES.md
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836  # v2.3.3
+      uses: softprops/action-gh-release@62c96d0c4e8a889135c1f3a25910db8dbe0e85f7  # v2.3.4
       with:
         tag_name: v${{ steps.get_version.outputs.version }}
         name: Release v${{ steps.get_version.outputs.version }}
@@ -106,7 +106,7 @@ jobs:
         compression-level: 9
 
     - name: Login to Docker Hub
-      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `softprops/action-gh-release`
  * From: 6cbd405e2c4e67a21c47fa9e383d020e4e28b836 (6cbd405e2c4e67a21c47fa9e383d020e4e28b836)
  * To: v2.3.4 (62c96d0c4e8a889135c1f3a25910db8dbe0e85f7)

* `docker/login-action`
  * From: 184bdaa0721073962dff0199f1fb9940f07167d1 (184bdaa0721073962dff0199f1fb9940f07167d1)
  * To: v3.6.0 (5e57cd118135c172c3672efd75eb46360885c0ef)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.