### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
       with:
         name: test-results-py${{ matrix.python-version }}-${{ matrix.docker-stage }}
         path: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -79,7 +79,7 @@ jobs:
         echo "- \`threatflux/yaraflux-mcp-server:${{ steps.get_version.outputs.version }}\` (production)" >> RELEASE_NOTES.md
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836  # v2.3.3
+      uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090  # v2.4.1
       with:
         tag_name: v${{ steps.get_version.outputs.version }}
         name: Release v${{ steps.get_version.outputs.version }}
@@ -94,7 +94,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
       with:
         name: release-artifacts-v${{ steps.get_version.outputs.version }}
         path: |
@@ -106,7 +106,7 @@ jobs:
         compression-level: 9
 
     - name: Login to Docker Hub
-      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/upload-artifact`
  * From: ea165f8d65b6e75b540449e92b4886f43607fa02 (ea165f8d65b6e75b540449e92b4886f43607fa02)
  * To: v5.0.0 (330a01c490aca151604b8cf639adc76d48f6c5d4)

* `softprops/action-gh-release`
  * From: 6cbd405e2c4e67a21c47fa9e383d020e4e28b836 (6cbd405e2c4e67a21c47fa9e383d020e4e28b836)
  * To: v2.4.1 (6da8fa9354ddfdc4aeace5fc48d7f679b5214090)

* `actions/upload-artifact`
  * From: ea165f8d65b6e75b540449e92b4886f43607fa02 (ea165f8d65b6e75b540449e92b4886f43607fa02)
  * To: v5.0.0 (330a01c490aca151604b8cf639adc76d48f6c5d4)

* `docker/login-action`
  * From: 184bdaa0721073962dff0199f1fb9940f07167d1 (184bdaa0721073962dff0199f1fb9940f07167d1)
  * To: v3.6.0 (5e57cd118135c172c3672efd75eb46360885c0ef)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.